### PR TITLE
TextToSlug method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Uploads one or more files from a multipart form submission contained within an `
 ```go
 func (u *Utils) MakeDirStructure(pathsToBeMade []string) error
 ```
-MakeDirStructure is a convenience method of the `utils` package which uses `os.MkdirAll` to creates
-a directory structure based on the slice of path strings provided. It returns nil when all the
-directories are successfully created, or else returns an error. The permission bits default to 0755,
-and are used for all directories created. If a path is already a directory, os.MkdirAll does nothing
-and returns nil, so MakeDirStructure will also return nil. If there's a permission issue encountered
-for any of the paths, the error reported by os.MkdirAll will be collected, and MakeDirStructure will
-return all encountered those errors as one.
+MakeDirStructure is a convenience method of the `utils` package which uses `os.MkdirAll` to creates a directory structure based on the slice of path strings provided. It returns nil when all the directories are successfully created, or else returns an error. The permission bits default to 0755, and are used for all directories created. If a path is already a directory, os.MkdirAll does nothing and returns nil, so MakeDirStructure will also return nil. If there's a permission issue encountered for any of the paths, the error reported by os.MkdirAll will be collected, and MakeDirStructure will return all encountered those errors as one.
+
+##### TextToSlug()
+The TextToSlug function converts accented characters to their unaccented versions, replaces all non-alphanumeric characters with dashes, trims redundant dashes, and converts the string to lowercase.
+This approach makes the slug both URL-friendly and human-readable.
+```go
+func (u *Utils) TextToSlug(input string) string 
+```
 
 ---
 ## Installation

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/loickreitmann/utils
 
 go 1.23.0
+
+require golang.org/x/text v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
+golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=

--- a/random_string_example_test.go
+++ b/random_string_example_test.go
@@ -11,8 +11,8 @@ func ExampleUtils_RandomString() {
 
 	str := u.RandomString(22)
 
-	fmt.Println("Random string of 22 characters:", str)
+	fmt.Printf("Random string has %d characters.\n", len(str))
 
 	// Output:
-	// Random string of 22 characters: StkgGpQ+u0lQL+q!5@BfsA
+	// Random string has 22 characters.
 }

--- a/text_to_slug.go
+++ b/text_to_slug.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// The removeAccents function uses the Unicode Normalization Form D (NFD) to decompose
+// characters into their base form and combining marks. It then removes diacritics by
+// filtering out the characters categorized under `unicode.Mn` (mark, nonspacing).
+func (u *Utils) removeAccents(s string) string {
+	// Normalize the string to NFD form to separate base characters from accents
+	t := norm.NFD.String(s)
+	var bldr strings.Builder
+	for _, r := range t {
+		// Skip combining marks (accents), thus removing diacritics
+		if unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		bldr.WriteRune(r)
+	}
+	return bldr.String()
+}
+
+// The ToSlug function converts accented characters to their unaccented versions,
+// replaces all non-alphanumeric characters with dashes, trims redundant dashes,
+// and converts the string to lowercase.
+// This approach makes the slug both URL-friendly and human-readable.
+func (u *Utils) TextToSlug(input string) string {
+	// Step 1: Remove accents
+	normalized := u.removeAccents(input)
+
+	// Step 2: Replace spaces and non-URL-friendly characters with dashes
+	// Allow only letters, numbers, and replace other characters with dashes
+	reg := regexp.MustCompile(`[^a-zA-Z0-9]+`)
+	slug := reg.ReplaceAllString(normalized, "-")
+
+	// Step 3: Trim and lowercase the slug
+	slug = strings.Trim(slug, "-")
+	slug = strings.ToLower(slug)
+
+	return slug
+}

--- a/text_to_slug.go
+++ b/text_to_slug.go
@@ -25,7 +25,7 @@ func (u *Utils) removeAccents(s string) string {
 	return bldr.String()
 }
 
-// The ToSlug function converts accented characters to their unaccented versions,
+// The TextToSlug function converts accented characters to their unaccented versions,
 // replaces all non-alphanumeric characters with dashes, trims redundant dashes,
 // and converts the string to lowercase.
 // This approach makes the slug both URL-friendly and human-readable.

--- a/text_to_slug_example_test.go
+++ b/text_to_slug_example_test.go
@@ -1,0 +1,29 @@
+package utils_test
+
+import (
+	"fmt"
+
+	"github.com/loickreitmann/utils"
+)
+
+func ExampleUtils_TextToSlug() {
+	var u utils.Utils
+	quotes := []string{
+		"Il est grand temps de rallumer les étoiles.",             // — Guillaume Apollinaire
+		"Cliché, but love conquers all.",                          // — Common English phrase
+		"La vida es sueño, y los sueños, sueños son.",             // — Pedro Calderón de la Barca
+		"Über den Wolken muss die Freiheit wohl grenzenlos sein.", // (Above the clouds, freedom must be boundless.) — Reinhard Mey
+		"Człowiek bez marzeń jest jak ptak bez skrzydeł.",         // (A person without dreams is like a bird without wings.) — Polish proverb
+	}
+
+	for _, quote := range quotes {
+		fmt.Println(u.TextToSlug(quote))
+	}
+
+	// Output:
+	// il-est-grand-temps-de-rallumer-les-etoiles
+	// cliche-but-love-conquers-all
+	// la-vida-es-sueno-y-los-suenos-suenos-son
+	// uber-den-wolken-muss-die-freiheit-wohl-grenzenlos-sein
+	// cz-owiek-bez-marzen-jest-jak-ptak-bez-skrzyde
+}

--- a/text_to_slug_fuzz_test.go
+++ b/text_to_slug_fuzz_test.go
@@ -1,0 +1,46 @@
+package utils_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/loickreitmann/utils"
+)
+
+// FuzzTextToSlug is a fuzz test for the TextToSlug function
+func FuzzUtils_TextToSlug(f *testing.F) {
+	// Add seed corpus
+	f.Add("Café con leche y croissants délicieux à l'étage")
+	f.Add("Привет мир!")
+	f.Add("こんにちは世界")
+	f.Add("Hello, World! @ # $")
+	f.Add("")
+
+	// Define the fuzzing function
+	f.Fuzz(func(t *testing.T, input string) {
+		var u utils.Utils
+		slug := u.TextToSlug(input)
+
+		// Basic property checks:
+		// Check if the output does not contain spaces
+		if strings.Contains(slug, " ") {
+			t.Errorf("Slug contains spaces: %q", slug)
+		}
+
+		// Check if the output is lowercase
+		if slug != strings.ToLower(slug) {
+			t.Errorf("Slug is not in lowercase: %q", slug)
+		}
+
+		// Check if the output does not contain consecutive dashes
+		if strings.Contains(slug, "--") {
+			t.Errorf("Slug contains consecutive dashes: %q", slug)
+		}
+
+		// Check if the output does not contain any non-permitted characters
+		if matched, _ := regexp.MatchString(`[^a-z0-9-]`, slug); matched {
+			t.Errorf("Slug contains non-permitted characters: %q", slug)
+		}
+	})
+}

--- a/utils.go
+++ b/utils.go
@@ -2,12 +2,16 @@
 // Inspired by Trevor Sawler's "Building a Module in Go." Udemy course.
 package utils
 
-// Utils is the type used to instantiate the module. Any variable of this type will have access to all
-// the methods with the *Utils receiver.
+// Utils is the type used to instantiate the module. Any variable of this type will
+// have access to all the methods with the *Utils receiver.
 type Utils struct {
 	UploadOptions
 }
 
+// Constructor for Utils struct that defines default options necessary when using
+// the UploadFiles and UploadOneFile methods.
+// MaxUploadFileSize: 1GB.
+// AllowedTypes: JPG, PNG, and GIF
 func New() *Utils {
 	return &Utils{
 		UploadOptions{


### PR DESCRIPTION
The TextToSlug function converts accented characters to their unaccented versions, replaces all non-alphanumeric characters with dashes, trims redundant dashes, and converts the string to lowercase.
This approach makes the slug both URL-friendly and human-readable.

Also added the Example and Fuzz tests for TextToSlug.